### PR TITLE
Fix DataFrame conversion in TextToMarkups

### DIFF
--- a/TextToMarkups/TextToMarkups.py
+++ b/TextToMarkups/TextToMarkups.py
@@ -29,7 +29,8 @@ def convert_to_markup_node(df_text):
 
     # read electrode from text ()
     cols = [ x for x in df_text.columns if x.endswith('XYZ')]
-    df_text = df_text[cols].map(lambda x: [float(a) for a in x.split(';')])
+    # DataFrame.map does not exist, the element-wise transformation must use applymap.
+    df_text = df_text[cols].applymap(lambda x: [float(a) for a in x.split(';')])
 
 
     for col in cols:


### PR DESCRIPTION
## Summary
- fix conversion of text columns to coordinate lists in TextToMarkups by using DataFrame.applymap instead of the nonexistent map method
- document the reason for the change in a code comment

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd4ec4db78832cb43822288df8e2c1